### PR TITLE
Update maxmind to include docker multi node envs

### DIFF
--- a/scripts/update_maxmind_database/README.md
+++ b/scripts/update_maxmind_database/README.md
@@ -1,9 +1,32 @@
 # Maxmind database update script
+
+## Table of Contents
+- [Introduction](#introduction)
+- [Execution](#execution)
+- [Example Usage](#example-usage)
+- [Docker Integration](#docker-integration)
+  - [Prerequisites](#prerequisites)
+  - [Configuration](#configuration)
+  - [Installation & Bootstrapping](#installation--bootstrapping)
+    - [Example of Placing the Script and Creating the Directories](#example-of-placing-the-script-and-creating-the-directories)
+  - [docker-compose.yml Snippet](#docker-composeyml-snippet)
+    - [Example docker-compose.yml Snippet](#example-docker-composeyml-snippet)
+  - [Running the Update Script](#running-the-update-script)
+  - [Example Output](#example-output)
+  - [Verifying the Update](#verifying-the-update)
+  - [Performing a Test with Updated Database Files](#performing-a-test-with-updated-database-files)
+
+## Introduction
 Custom bash script for pulling the latest Maxmind GeoIP database and checking if the current version on the server (Wazuh) has the latest update, if not, replace it and have the indexer use the updated version.
 
-Note: this is done for an All-in-One environment, but can be updated for distributed environments with multiple indexers, the script must be located on every indexer node.
-## Introduction
-It essentially does the following:
+> Note: this is done for an All-in-One environment and docker multi-node deployments, but can be updated for distributed environments with multiple indexers, the script must be located on every indexer node.
+
+There are two versions of the script:
+
+- `update_maxmind.sh`: For both containerized and non-containerized Wazuh installations as it has a more complex logic to handle different environments.
+- `update_maxmind_onprem.sh`: For non-containerized Wazuh installations, although this script might be best for users that prefer a more simple script.
+
+This script essentially does the following:
 
 1. Authenticates to MaxMind using your Account ID and License Key.
 2. Downloads the latest GeoLite2 Country, City, and ASN databases via curl -sSL.
@@ -20,7 +43,7 @@ crontab -e
 0 3 * * * /usr/local/bin/update_maxmind.sh >> /var/log/update_maxmind.log 2>&1
 ```
 
-## Example
+## Example Usage
 ```bash
 [root@wazuh-server maxmind]# bash update_maxmind.sh 
 Stopping Wazuh Indexer service...
@@ -68,3 +91,482 @@ No updates were necessary; Wazuh Indexer will be ensured running by EXIT trap.
 Ensuring Wazuh Indexer service is running...
   Wazuh Indexer started.
 ```
+
+## Docker Integration
+
+If you are running Wazuh in a Docker container, make sure to adjust the paths and environment variables accordingly.
+
+This document describes how to integrate and test the `update_maxmind.sh` script in a multi-node Docker deployment of Wazuh Indexer. The script automates downloading and binding the latest GeoLite2 databases into each indexer container.
+
+### Prerequisites
+
+* Docker and Docker Compose installed
+* A multi-node Wazuh deployment managed via `docker-compose.yml`
+* MaxMind **Account ID** and **License Key**
+
+## Configuration
+
+Edit the top of `update_maxmind.sh` to set your own environment variables. Replace the placeholders below (in the script):
+
+```bash
+# Path to your project root (where docker-compose.yml lives)
+PROJECT_ROOT="/path/to/your/wazuh-docker/multi-node"
+CONTAINER=true  # Set to true
+
+# Directory under config/ for GeoIP DBs and scripts
+GEOIP_DIR="${PROJECT_ROOT}/config/wazuh_indexer/geoip-data"
+SCRIPT_DIR="${PROJECT_ROOT}/config/wazuh_indexer/scripts"
+
+# MaxMind credentials
+ACCOUNT_ID="YOUR_MAXMIND_ACCOUNT_ID"
+LICENSE_KEY="YOUR_MAXMIND_LICENSE_KEY"
+
+# Wazuh Indexer Docker image (must match your used version)
+INDEXER_IMAGE="wazuh/wazuh-indexer:4.12.0"
+```
+
+## Installation & Bootstrapping
+
+1. **Bring up your cluster** (if not already running):
+
+   ```bash
+   cd "${PROJECT_ROOT}"
+   docker-compose up -d
+   ```
+
+2. **Prepare the GeoIP folders and scripts**:
+
+   ```bash
+   mkdir -p "${GEOIP_DIR}"
+   mkdir -p "${SCRIPT_DIR}"
+   chmod +x "${SCRIPT_DIR}/update_maxmind.sh"
+   ```
+
+<details>
+<summary>Example of placing the script and creating the directories</summary>
+
+```bash
+> sudo docker-compose up -d
+
+[+] Running 7/7
+ ⠿ Container multi-node-wazuh2.indexer-1   Running                                                                                                                                                 0.0s
+ ⠿ Container multi-node-wazuh3.indexer-1   Running                                                                                                                                                 0.0s
+ ⠿ Container multi-node-wazuh.worker-1     Running                                                                                                                                                 0.0s
+ ⠿ Container multi-node-nginx-1            Started                                                                                                                                                 1.1s
+ ⠿ Container multi-node-wazuh1.indexer-1   Started                                                                                                                                                 0.3s
+ ⠿ Container multi-node-wazuh.master-1     Started                                                                                                                                                 0.3s
+ ⠿ Container multi-node-wazuh.dashboard-1  Started                                                                                                                                                 0.2s
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?3                                                                                                                                           
+> xdg-open  docker-compose.yml 
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?3                                                                                                                                           
+> ls
+config  docker-compose.yml  generate-indexer-certs.yml  Migration-to-Wazuh-4.4.md  README.md  volume-migrator.sh
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?3                                                                                                                                           
+> mkdir config/wazuh_indexer/geoip-data
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?3                                                                                                                                           
+> mkdir config/wazuh_indexer/scripts   
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?3                                                                                                                                           
+> cp ../single-node/config/wazuh_indexer/scripts/update_maxmind.sh config/wazuh_indexer/scripts 
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !1 ?4                                                                                                                                           
+> ll config/wazuh_indexer           
+total 24K
+drwxr-xr-x 2 leon leon 4.0K Jul 24 09:42 geoip-data
+-rw-r--r-- 1 leon leon 1.3K Jul 10 11:53 internal_users.yml
+drwxr-xr-x 2 leon leon 4.0K Jul 24 09:42 scripts
+-rw-r--r-- 1 leon leon 1.8K Jul 10 11:53 wazuh1.indexer.yml
+-rw-r--r-- 1 leon leon 1.8K Jul 10 11:53 wazuh2.indexer.yml
+-rw-r--r-- 1 leon leon 1.8K Jul 10 11:53 wazuh3.indexer.yml
+```
+</details>
+
+## docker-compose.yml Snippet
+
+Ensure each indexer service binds the GeoLite2 files from your host folder:
+
+```yaml
+services:
+  wazuh1.indexer:
+    image: ${INDEXER_IMAGE}
+    volumes:
+      ...
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-City.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-City.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-Country.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-Country.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-ASN.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-ASN.mmdb
+  wazuh2.indexer:
+    # same volumes as above
+  wazuh3.indexer:
+    # same volumes as above
+```
+
+### Example docker-compose.yml Snippet
+<details>
+<summary>Example docker-compose.yml snippet</summary>
+
+```bash
+> cat docker-compose.yml | grep -Ei "Geoip" -A1 -B27
+
+  wazuh1.indexer:
+    image: wazuh/wazuh-indexer:4.12.0
+    hostname: wazuh1.indexer
+    restart: always
+    ports:
+      - "9200:9200"
+    environment:
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "bootstrap.memory_lock=true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - wazuh-indexer-data-1:/var/lib/wazuh-indexer
+      - ./config/wazuh_indexer_ssl_certs/root-ca.pem:/usr/share/wazuh-indexer/certs/root-ca.pem
+      - ./config/wazuh_indexer_ssl_certs/wazuh1.indexer-key.pem:/usr/share/wazuh-indexer/certs/wazuh1.indexer.key
+      - ./config/wazuh_indexer_ssl_certs/wazuh1.indexer.pem:/usr/share/wazuh-indexer/certs/wazuh1.indexer.pem
+      - ./config/wazuh_indexer_ssl_certs/admin.pem:/usr/share/wazuh-indexer/certs/admin.pem
+      - ./config/wazuh_indexer_ssl_certs/admin-key.pem:/usr/share/wazuh-indexer/certs/admin-key.pem
+      - ./config/wazuh_indexer/wazuh1.indexer.yml:/usr/share/wazuh-indexer/opensearch.yml
+      - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-City.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-City.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-Country.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-Country.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-ASN.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-ASN.mmdb
+
+  wazuh2.indexer:
+    image: wazuh/wazuh-indexer:4.12.0
+    hostname: wazuh2.indexer
+    restart: always
+    environment:
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "bootstrap.memory_lock=true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - wazuh-indexer-data-2:/var/lib/wazuh-indexer
+      - ./config/wazuh_indexer_ssl_certs/root-ca.pem:/usr/share/wazuh-indexer/certs/root-ca.pem
+      - ./config/wazuh_indexer_ssl_certs/wazuh2.indexer-key.pem:/usr/share/wazuh-indexer/certs/wazuh2.indexer.key
+      - ./config/wazuh_indexer_ssl_certs/wazuh2.indexer.pem:/usr/share/wazuh-indexer/certs/wazuh2.indexer.pem
+      - ./config/wazuh_indexer/wazuh2.indexer.yml:/usr/share/wazuh-indexer/opensearch.yml
+      - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-City.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-City.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-Country.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-Country.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-ASN.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-ASN.mmdb
+
+  wazuh3.indexer:
+    image: wazuh/wazuh-indexer:4.12.0
+    hostname: wazuh3.indexer
+    restart: always
+    environment:
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "bootstrap.memory_lock=true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - wazuh-indexer-data-3:/var/lib/wazuh-indexer
+      - ./config/wazuh_indexer_ssl_certs/root-ca.pem:/usr/share/wazuh-indexer/certs/root-ca.pem
+      - ./config/wazuh_indexer_ssl_certs/wazuh3.indexer-key.pem:/usr/share/wazuh-indexer/certs/wazuh3.indexer.key
+      - ./config/wazuh_indexer_ssl_certs/wazuh3.indexer.pem:/usr/share/wazuh-indexer/certs/wazuh3.indexer.pem
+      - ./config/wazuh_indexer/wazuh3.indexer.yml:/usr/share/wazuh-indexer/opensearch.yml
+      - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-City.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-City.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-Country.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-Country.mmdb
+      - type: bind
+        source: ./config/wazuh_indexer/geoip-data/GeoLite2-ASN.mmdb
+        target: /usr/share/wazuh-indexer/modules/ingest-geoip/GeoLite2-ASN.mmdb
+```
+</details>
+
+## Running the Update Script
+
+From your project root, execute:
+
+```bash
+"${SCRIPT_DIR}/update_maxmind.sh"
+```
+
+The script will:
+
+1. Detect all running indexer containers by image
+2. Bootstrap default `.mmdb` files into `config/wazuh_indexer/geoip-data/` if empty
+3. Stop all indexer containers to update the GeoIP databases
+4. Download, compare, and update any changed GeoLite2 databases
+5. Recreate each indexer service so Docker re-mounts the updated files
+6. Ensure all indexer containers are back up
+
+## Example Output
+
+<details>
+<summary>Example output from running the script</summary>
+
+```bash
+> ls -la config/wazuh_indexer/geoip-data
+total 8
+drwxr-xr-x 2 leon leon 4096 Jul 24 09:42 .
+drwxr-xr-x 4 leon leon 4096 Jul 24 09:42 ..
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?4                                                                                                                                           
+> ls -la config/wazuh_indexer/scripts   
+total 16
+drwxr-xr-x 2 leon leon 4096 Jul 24 09:42 .
+drwxr-xr-x 4 leon leon 4096 Jul 24 09:42 ..
+-rwxr-xr-x 1 leon leon 7373 Jul 24 09:42 update_maxmind.sh
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?4                                                                                                                                           
+> sudo docker ps
+CONTAINER ID   IMAGE                          COMMAND                  CREATED       STATUS       PORTS                                                                                                                                                       NAMES
+0a80f36d5933   nginx:stable                   "/docker-entrypoint.…"   4 hours ago   Up 4 hours   80/tcp, 0.0.0.0:1514->1514/tcp, [::]:1514->1514/tcp                                                                                                         multi-node-nginx-1
+12e1eeb4b0f9   wazuh/wazuh-dashboard:4.12.0   "/entrypoint.sh"         4 hours ago   Up 4 hours   443/tcp, 0.0.0.0:443->5601/tcp, [::]:443->5601/tcp                                                                                                          multi-node-wazuh.dashboard-1
+a70a1efb2466   wazuh/wazuh-manager:4.12.0     "/init"                  4 hours ago   Up 4 hours   1514/tcp, 0.0.0.0:1515->1515/tcp, [::]:1515->1515/tcp, 0.0.0.0:514->514/udp, [::]:514->514/udp, 1516/tcp, 0.0.0.0:55000->55000/tcp, [::]:55000->55000/tcp   multi-node-wazuh.master-1
+6447b133bbd1   wazuh/wazuh-indexer:4.12.0     "/entrypoint.sh open…"   4 hours ago   Up 4 hours   0.0.0.0:9200->9200/tcp, [::]:9200->9200/tcp                                                                                                                 multi-node-wazuh1.indexer-1
+f1a27f9deccc   wazuh/wazuh-indexer:4.12.0     "/entrypoint.sh open…"   4 hours ago   Up 4 hours   9200/tcp                                                                                                                                                    multi-node-wazuh2.indexer-1
+7dc2fba75c98   wazuh/wazuh-manager:4.12.0     "/init"                  4 hours ago   Up 4 hours   1514-1516/tcp, 514/udp, 55000/tcp                                                                                                                           multi-node-wazuh.worker-1
+f136d9308022   wazuh/wazuh-indexer:4.12.0     "/entrypoint.sh open…"   4 hours ago   Up 4 hours   9200/tcp                                                                                                                                                    multi-node-wazuh3.indexer-1
+> ./config/wazuh_indexer/scripts/update_maxmind.sh
+Found indexer containers:
+  • multi-node-wazuh3.indexer-1
+  • multi-node-wazuh2.indexer-1
+  • multi-node-wazuh1.indexer-1
+Detected services to recreate: wazuh3.indexer wazuh2.indexer wazuh1.indexer
+GeoIP dir is empty; bootstrapping default .mmdb files…
+  • Copying GeoLite2-City.mmdb
+Successfully copied 62.9MB to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data
+  • Copying GeoLite2-Country.mmdb
+Successfully copied 3.99MB to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data
+  • Copying GeoLite2-ASN.mmdb
+Successfully copied 6.61MB to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data
+Bootstrapped GeoIP DBs into /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data
+Stopping indexer...
+Stopping all indexer containers…
+  • multi-node-wazuh3.indexer-1
+multi-node-wazuh3.indexer-1
+  • multi-node-wazuh2.indexer-1
+multi-node-wazuh2.indexer-1
+  • multi-node-wazuh1.indexer-1
+multi-node-wazuh1.indexer-1
+  Wazuh Indexer stopped.
+Checking GeoLite2-Country...
+  Extracted GeoLite2-Country.mmdb to temporary file.
+  New or changed GeoLite2-Country detected; installing updated .mmdb...
+  Moved GeoLite2-Country.mmdb to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data/GeoLite2-Country.mmdb
+Checking GeoLite2-City...
+  Extracted GeoLite2-City.mmdb to temporary file.
+  New or changed GeoLite2-City detected; installing updated .mmdb...
+  Moved GeoLite2-City.mmdb to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data/GeoLite2-City.mmdb
+Checking GeoLite2-ASN...
+  Extracted GeoLite2-ASN.mmdb to temporary file.
+  New or changed GeoLite2-ASN detected; installing updated .mmdb...
+  Moved GeoLite2-ASN.mmdb to /home/leon/MyVagrant/docker/wazuh-docker/multi-node/config/wazuh_indexer/geoip-data/GeoLite2-ASN.mmdb
+Updates applied; restarting indexer...
+Updates applied; recreating indexer containers to pick up new mounts…
+  • Removing old container for service 'wazuh3.indexer'…
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh3.indexer-1  Stopped                                                                                                                                                  0.0s
+Going to remove multi-node-wazuh3.indexer-1
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh3.indexer-1  Removed                                                                                                                                                  0.0s
+[+] Running 1/1
+ ⠿ Container multi-node-wazuh3.indexer-1  Started                                                                                                                                                  0.2s
+     Recreated wazuh3.indexer
+  • Removing old container for service 'wazuh2.indexer'…
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh2.indexer-1  Stopped                                                                                                                                                  0.0s
+Going to remove multi-node-wazuh2.indexer-1
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh2.indexer-1  Removed                                                                                                                                                  0.0s
+[+] Running 1/1
+ ⠿ Container multi-node-wazuh2.indexer-1  Started                                                                                                                                                  0.2s
+     Recreated wazuh2.indexer
+  • Removing old container for service 'wazuh1.indexer'…
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh1.indexer-1  Stopped                                                                                                                                                  0.0s
+Going to remove multi-node-wazuh1.indexer-1
+[+] Running 1/0
+ ⠿ Container multi-node-wazuh1.indexer-1  Removed                                                                                                                                                  0.0s
+[+] Running 1/1
+ ⠿ Container multi-node-wazuh1.indexer-1  Started                                                                                                                                                  0.3s
+     Recreated wazuh1.indexer
+All indexer containers have been recreated with updated mounts.
+MaxMind GeoLite2 databases have been updated successfully.
+Ensuring indexer is running...
+Ensuring all indexers are running…
+  • multi-node-wazuh3.indexer-1 is already running.
+  • multi-node-wazuh2.indexer-1 is already running.
+  • multi-node-wazuh1.indexer-1 is already running.
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                        5s 
+> sudo docker exec multi-node-wazuh2.indexer-1 ls -l /usr/share/wazuh-indexer/modules/ingest-geoip
+total 82116
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 10706647 Jul 24 12:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 61731202 Jul 24 12:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer  9752788 Jul 24 12:04 GeoLite2-Country.mmdb
+-rw-r----- 1 wazuh-indexer wazuh-indexer    61668 Apr 30 10:54 geoip2-4.2.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    27727 Apr 30 10:54 ingest-geoip-2.19.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    78494 Apr 30 10:54 jackson-annotations-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer  1658755 Apr 30 10:54 jackson-databind-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    39021 Apr 30 10:54 maxmind-db-3.1.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1973 Apr 30 10:54 plugin-descriptor.properties
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1764 Apr 30 10:54 plugin-security.policy
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                  
+> ls -la config/wazuh_indexer/geoip-data
+total 80284
+drwxr-xr-x 2 leon leon     4096 Jul 24 14:04 .
+drwxr-xr-x 4 leon leon     4096 Jul 24 09:42 ..
+-rw-r--r-- 1 leon leon 10706647 Jul 24 14:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 leon leon 61731202 Jul 24 14:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 leon leon  9752788 Jul 24 14:04 GeoLite2-Country.mmdb
+```
+</details>
+
+### Verifying the Update
+<details>
+<summary>Verifying the Update</summary>
+
+```bash
+> sudo docker exec multi-node-wazuh2.indexer-1 ls -l /usr/share/wazuh-indexer/modules/ingest-geoip
+total 82116
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 10706647 Jul 24 12:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 61731202 Jul 24 12:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer  9752788 Jul 24 12:04 GeoLite2-Country.mmdb
+-rw-r----- 1 wazuh-indexer wazuh-indexer    61668 Apr 30 10:54 geoip2-4.2.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    27727 Apr 30 10:54 ingest-geoip-2.19.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    78494 Apr 30 10:54 jackson-annotations-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer  1658755 Apr 30 10:54 jackson-databind-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    39021 Apr 30 10:54 maxmind-db-3.1.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1973 Apr 30 10:54 plugin-descriptor.properties
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1764 Apr 30 10:54 plugin-security.policy
+> ls -la config/wazuh_indexer/geoip-data
+total 80284
+drwxr-xr-x 2 leon leon     4096 Jul 24 14:04 .
+drwxr-xr-x 4 leon leon     4096 Jul 24 09:42 ..
+-rw-r--r-- 1 leon leon 10706647 Jul 24 14:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 leon leon 61731202 Jul 24 14:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 leon leon  9752788 Jul 24 14:04 GeoLite2-Country.mmdb
+```
+
+</details>
+
+You should see the three `.mmdb` files alongside the plugin JARs and properties.
+
+### Performing a test with updated database files
+<details>
+<summary>Performing a test with updated database files (no need to replace them)</summary>
+
+```bash
+> ./config/wazuh_indexer/scripts/update_maxmind.sh
+Found indexer containers:
+  • multi-node-wazuh1.indexer-1
+  • multi-node-wazuh2.indexer-1
+  • multi-node-wazuh3.indexer-1
+Detected services to recreate: wazuh1.indexer wazuh2.indexer wazuh3.indexer
+GeoIP dir already populated; skipping bootstrap.
+Stopping indexer...
+Stopping all indexer containers…
+  • multi-node-wazuh1.indexer-1
+multi-node-wazuh1.indexer-1
+  • multi-node-wazuh2.indexer-1
+multi-node-wazuh2.indexer-1
+  • multi-node-wazuh3.indexer-1
+multi-node-wazuh3.indexer-1
+  Wazuh Indexer stopped.
+Checking GeoLite2-Country...
+  Extracted GeoLite2-Country.mmdb to temporary file.
+  GeoLite2-Country is up to date (contents identical).
+Checking GeoLite2-City...
+  Extracted GeoLite2-City.mmdb to temporary file.
+  GeoLite2-City is up to date (contents identical).
+Checking GeoLite2-ASN...
+  Extracted GeoLite2-ASN.mmdb to temporary file.
+  GeoLite2-ASN is up to date (contents identical).
+No updates needed; indexer will be ensured up by trap.
+Ensuring indexer is running...
+Ensuring all indexers are running…
+multi-node-wazuh1.indexer-1
+  • Started multi-node-wazuh1.indexer-1
+multi-node-wazuh2.indexer-1
+  • Started multi-node-wazuh2.indexer-1
+multi-node-wazuh3.indexer-1
+  • Started multi-node-wazuh3.indexer-1
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                       4s 
+> 
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                       4s 
+> ls -la config/wazuh_indexer/geoip-data
+total 80284
+drwxr-xr-x 2 leon leon     4096 Jul 24 14:04 .
+drwxr-xr-x 4 leon leon     4096 Jul 24 09:42 ..
+-rw-r--r-- 1 leon leon 10706647 Jul 24 14:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 leon leon 61731202 Jul 24 14:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 leon leon  9752788 Jul 24 14:04 GeoLite2-Country.mmdb
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                          
+> sudo docker exec multi-node-wazuh2.indexer-1 ls -l /usr/share/wazuh-indexer/modules/ingest-geoip
+total 82116
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 10706647 Jul 24 12:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 61731202 Jul 24 12:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer  9752788 Jul 24 12:04 GeoLite2-Country.mmdb
+-rw-r----- 1 wazuh-indexer wazuh-indexer    61668 Apr 30 10:54 geoip2-4.2.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    27727 Apr 30 10:54 ingest-geoip-2.19.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    78494 Apr 30 10:54 jackson-annotations-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer  1658755 Apr 30 10:54 jackson-databind-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    39021 Apr 30 10:54 maxmind-db-3.1.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1973 Apr 30 10:54 plugin-descriptor.properties
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1764 Apr 30 10:54 plugin-security.policy
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                          
+> sudo docker exec multi-node-wazuh1.indexer-1 ls -l /usr/share/wazuh-indexer/modules/ingest-geoip
+total 82116
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 10706647 Jul 24 12:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 61731202 Jul 24 12:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer  9752788 Jul 24 12:04 GeoLite2-Country.mmdb
+-rw-r----- 1 wazuh-indexer wazuh-indexer    61668 Apr 30 10:54 geoip2-4.2.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    27727 Apr 30 10:54 ingest-geoip-2.19.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    78494 Apr 30 10:54 jackson-annotations-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer  1658755 Apr 30 10:54 jackson-databind-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    39021 Apr 30 10:54 maxmind-db-3.1.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1973 Apr 30 10:54 plugin-descriptor.properties
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1764 Apr 30 10:54 plugin-security.policy
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                                                                                          
+> sudo docker exec multi-node-wazuh3.indexer-1 ls -l /usr/share/wazuh-indexer/modules/ingest-geoip
+total 82116
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 10706647 Jul 24 12:04 GeoLite2-ASN.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer 61731202 Jul 24 12:04 GeoLite2-City.mmdb
+-rw-r--r-- 1 wazuh-indexer wazuh-indexer  9752788 Jul 24 12:04 GeoLite2-Country.mmdb
+-rw-r----- 1 wazuh-indexer wazuh-indexer    61668 Apr 30 10:54 geoip2-4.2.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    27727 Apr 30 10:54 ingest-geoip-2.19.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    78494 Apr 30 10:54 jackson-annotations-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer  1658755 Apr 30 10:54 jackson-databind-2.18.2.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer    39021 Apr 30 10:54 maxmind-db-3.1.1.jar
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1973 Apr 30 10:54 plugin-descriptor.properties
+-rw-r----- 1 wazuh-indexer wazuh-indexer     1764 Apr 30 10:54 plugin-security.policy
+ ~/MyVagrant/docker/wazuh-docker/multi-node | #v4.12.0 !2 ?5                                                                              
+```
+
+</details>

--- a/scripts/update_maxmind_database/update_maxmind.sh
+++ b/scripts/update_maxmind_database/update_maxmind.sh
@@ -10,27 +10,113 @@ set -euo pipefail
 ###############
 # 1. Configuration
 ###############
+# Set to "true" if running in Docker mode, "false" for systemd mode (non-containerized):
+CONTAINER=false
+
 ACCOUNT_ID="..."   # Your MaxMind Account ID
 LICENSE_KEY="..."  # Your MaxMind License Key
 DB_TYPES=("GeoLite2-Country" "GeoLite2-City" "GeoLite2-ASN")
-DEST_DIR="/usr/share/wazuh-indexer/modules/ingest-geoip"
 TEMP_DIR="$(mktemp -d)"
 UPDATED_ANY=false
 
+# Container variables
+if [[ "$CONTAINER" == true ]]; then
+    DEST_DIR=".../multi-node/config/wazuh_indexer/geoip-data" # Your host path
+    DEFAULT_IMAGE="wazuh/wazuh-indexer:4.12.0" # Default image to use for bootstrapping <-- Please change to your version
+    COMPOSE_FILE=".../multi-node/docker-compose.yml" # Your file path
+    
+    INDEXERS=$(sudo docker ps --filter "ancestor="${DEFAULT_IMAGE}"" --format "{{.Names}}")
+    
+    if [[ -z "$INDEXERS" ]]; then
+      echo "No running indexer containers for image ${DEFAULT_IMAGE}" >&2
+      exit 1
+    fi
+
+    echo "Found indexer containers:"
+    while read -r c; do
+      echo "  • $c"
+    done <<<"$INDEXERS"
+    
+    SERVICES=""
+    for c in $INDEXERS; do
+      # e.g. multi-node-wazuh1.indexer-1 → wazuh1.indexer
+      svc=${c#multi-node-}           # remove project name and hyphen
+      svc=${svc%-[0-9]*}            # remove trailing -1, -2, etc.
+      SERVICES="$SERVICES $svc"
+    done
+
+    echo "Detected services to recreate:$SERVICES"
+    
+    # --- Bootstrap host dir only if empty ---
+    mkdir -p "$DEST_DIR"
+    # If it's empty, seed just the three GeoIP DBs from a fresh image
+    if [ -z "$(ls -A "$DEST_DIR")" ]; then
+      echo "GeoIP dir is empty; bootstrapping default .mmdb files…"
+      # 1) Create a stopped container from the default image
+      TMP_CID=$(docker create "$DEFAULT_IMAGE")
+
+      # 2) Copy each DB file out into our host folder
+      for f in GeoLite2-City.mmdb GeoLite2-Country.mmdb GeoLite2-ASN.mmdb; do
+        echo "  • Copying $f"
+        docker cp "${TMP_CID}":/usr/share/wazuh-indexer/modules/ingest-geoip/"$f" "$DEST_DIR"
+      done
+
+      # 3) Clean up the temp container
+      docker rm "$TMP_CID" >/dev/null
+      echo "Bootstrapped GeoIP DBs into $DEST_DIR"
+    else
+      echo "GeoIP dir already populated; skipping bootstrap."
+    fi
+else
+    DEST_DIR="/usr/share/wazuh-indexer/modules/ingest-geoip"
+fi
 #############################
 # 2. Ensure Wazuh Indexer is running (called on exit)
 #############################
+stop_indexer() {
+  if [[ "$CONTAINER" == true ]]; then
+      echo "Stopping all indexer containers…"
+      for c in $INDEXERS; do
+        echo "  • $c"
+        sudo docker stop "$c" || echo "  Could not stop $c"
+      done
+  else
+    echo "Stopping systemd service wazuh-indexer..."
+    sudo systemctl stop wazuh-indexer || true
+  fi
+}
+
+start_indexer() {
+  if [[ "$CONTAINER" == true ]]; then
+    echo "Starting all indexer containers…"
+    for c in $INDEXERS; do
+      echo "  • $c"
+      sudo docker start "$c" || echo "  Could not start $c"
+    done
+  else
+    echo "Starting systemd service wazuh-indexer..."
+    sudo systemctl start wazuh-indexer
+  fi
+}
 ensure_indexer_running() {
-    echo "Ensuring Wazuh Indexer service is running..."
+  echo "Ensuring indexer is running..."
+  if [[ "$CONTAINER" == true ]]; then
+    echo "Ensuring all indexers are running…"
+    for c in $INDEXERS; do
+      if ! sudo docker ps --filter "name=$c" --filter "status=running" \
+           | grep -qw "$c"; then
+        sudo docker start "$c" && echo "  • Started $c" || echo "  Failed $c"
+      else
+        echo "  • $c is already running."
+      fi
+    done
+  else
     if ! systemctl is-active --quiet wazuh-indexer; then
-        if systemctl start wazuh-indexer; then
-            echo "  Wazuh Indexer started."
-        else
-            echo "  ERROR: Failed to start Wazuh Indexer." >&2
-        fi
+      start_indexer
     else
-        echo "  Wazuh Indexer is already running."
+      echo "  Systemd service is already active."
     fi
+  fi
 }
 trap ensure_indexer_running EXIT
 
@@ -72,21 +158,60 @@ update_db() {
     echo "  Moved ${db}.mmdb to ${dest_file}"
 
     # 3.e Set correct ownership
-    chown wazuh-indexer:wazuh-indexer "${dest_file}"
-
+    if [[ "$CONTAINER" == true ]]; then
+      sudo chown -R 1000:1000 "${dest_file}"
+    else
+      chown wazuh-indexer:wazuh-indexer "${dest_file}"
+    fi
+    
     UPDATED_ANY=true
     return 0
 }
 
+# Rollback function: restores original GeoLite2 DBs from the image
+rollback_geoip() {
+  echo "⏪ Rolling back GeoIP DBs to default image versions…"
+
+  # 1) Spin up a stopped container from the default image
+  local tmp_cid
+  tmp_cid=$(sudo docker create "wazuh/wazuh-indexer:4.12.0")  # create returns the new container ID
+
+  # 2) Copy each of the three DB files back into DEST_DIR
+  for f in GeoLite2-City.mmdb GeoLite2-Country.mmdb GeoLite2-ASN.mmdb; do
+    echo "   • Restoring $f"
+    sudo docker cp "${tmp_cid}":/usr/share/wazuh-indexer/modules/ingest-geoip/"$f" \
+      "${DEST_DIR}/${f}"                               # cp works on stopped containers
+    sudo chown 1000:1000 "${DEST_DIR}/${f}"                  # ensure correct ownership
+  done
+
+  # 3) Clean up the temporary container
+  sudo docker rm "${tmp_cid}" >/dev/null
+
+  # 4) Recreate the indexer so it picks up the rolled-back files
+  echo "🔄 Restarting indexer container…"
+  sudo docker-compose -f "${COMPOSE_FILE}" up -d --force-recreate "${CONTAINER_NAME}"
+  echo "✅ Rollback complete."
+}
+
+
 #############################
 # 4. Stop Wazuh Indexer before updates (optional but recommended)
 #############################
-echo "Stopping Wazuh Indexer service..."
-if systemctl is-active --quiet wazuh-indexer; then
-    systemctl stop wazuh-indexer
+echo "Stopping indexer..."
+if [[ "$CONTAINER" == true ]]; then
+    #if sudo docker ps --filter "name=${CONTAINER_NAME}" --filter "status=running" | grep -q "${CONTAINER_NAME}"; then
+    stop_indexer
     echo "  Wazuh Indexer stopped."
+    #else
+     #   echo "  Wazuh Indexer is not running; skipping stop."
+    #fi
 else
-    echo "  Wazuh Indexer is not running; skipping stop."
+    if systemctl is-active --quiet wazuh-indexer; then
+        stop_indexer
+        echo "  Wazuh Indexer stopped."
+    else
+        echo "  Wazuh Indexer is not running; skipping stop."
+    fi
 fi
 
 #############################
@@ -107,15 +232,22 @@ rm -rf "${TEMP_DIR}"
 # 7. Restart Wazuh Indexer if any DB was updated
 #############################
 if [[ "${UPDATED_ANY}" == true ]]; then
-    echo "Restarting Wazuh Indexer service..."
-    if systemctl restart wazuh-indexer; then
-        echo "  Wazuh Indexer restarted."
-        echo "MaxMind GeoLite2 databases have been updated successfully."
+    echo "Updates applied; restarting indexer..."
+    if [[ "$CONTAINER" == true ]]; then
+      echo "Updates applied; recreating indexer containers to pick up new mounts…"
+      for svc in $SERVICES; do
+        echo "  • Removing old container for service '$svc'…"
+        docker-compose -f "$COMPOSE_FILE" rm -sf "$svc" \
+          && docker-compose -f "$COMPOSE_FILE" up -d --force-recreate "$svc" \
+          && echo "     Recreated $svc" || echo "    Failed to recreate $svc"
+      done
+      echo "All indexer containers have been recreated with updated mounts."
     else
-        echo "  ERROR: Failed to restart Wazuh Indexer." >&2
+        sudo systemctl restart wazuh-indexer
     fi
+    echo "MaxMind GeoLite2 databases have been updated successfully."
 else
-    echo "No updates were necessary; Wazuh Indexer will be ensured running by EXIT trap."
+    echo "No updates needed; indexer will be ensured up by trap."
 fi
 
 exit 0

--- a/scripts/update_maxmind_database/update_maxmind_onprem.sh
+++ b/scripts/update_maxmind_database/update_maxmind_onprem.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+#
+# update_maxmind.sh --> For non-containerized Wazuh installations
+#  Automates GeoLite2-Country, GeoLite2-City, and GeoLite2-ASN updates for Wazuh.
+#  Downloads each tarball, extracts the .mmdb, compares byte-by-byte to avoid unnecessary updates.
+#
+
+###############
+# 1. Configuration
+###############
+ACCOUNT_ID="..."   # Your MaxMind Account ID
+LICENSE_KEY="..."  # Your MaxMind License Key
+DB_TYPES=("GeoLite2-Country" "GeoLite2-City" "GeoLite2-ASN")
+DEST_DIR="/usr/share/wazuh-indexer/modules/ingest-geoip"
+TEMP_DIR="$(mktemp -d)"
+UPDATED_ANY=false
+
+#############################
+# 2. Ensure Wazuh Indexer is running (called on exit)
+#############################
+ensure_indexer_running() {
+    echo "Ensuring Wazuh Indexer service is running..."
+    if ! systemctl is-active --quiet wazuh-indexer; then
+        if systemctl start wazuh-indexer; then
+            echo "  Wazuh Indexer started."
+        else
+            echo "  ERROR: Failed to start Wazuh Indexer." >&2
+        fi
+    else
+        echo "  Wazuh Indexer is already running."
+    fi
+}
+trap ensure_indexer_running EXIT
+
+#############################
+# 3. Download, extract, compare, and update one database
+#############################
+update_db() {
+    local db="$1"
+    local suffix="tar.gz"
+    local download_url="https://download.maxmind.com/app/geoip_download?edition_id=${db}&license_key=${LICENSE_KEY}&suffix=${suffix}"
+    local dest_file="${DEST_DIR}/${db}.mmdb"
+    local tmp_mmdb="${TEMP_DIR}/${db}.mmdb"
+
+    echo "Checking ${db}..."
+
+    # 3.a Download & extract .mmdb into a temp file in one step :contentReference[oaicite:2]{index=2}
+    if ! curl -sSL --fail -u "${ACCOUNT_ID}:${LICENSE_KEY}" "${download_url}" \
+         | tar -xOzf - --wildcards "*/${db}.mmdb" --strip-components=1 > "${tmp_mmdb}"; then
+        echo "  ERROR: Failed to download or extract ${db}.mmdb" >&2
+        [[ -f "${tmp_mmdb}" ]] && rm -f "${tmp_mmdb}"
+        return 1
+    fi
+    echo "  Extracted ${db}.mmdb to temporary file."
+
+    # 3.b If existing .mmdb is present, compare against the new one using cmp :contentReference[oaicite:3]{index=3}
+    if [[ -f "${dest_file}" ]]; then
+        if cmp --silent -- "${tmp_mmdb}" "${dest_file}"; then
+            echo "  ${db} is up to date (contents identical)."
+            rm -f "${tmp_mmdb}"
+            return 0
+        fi
+    fi
+
+    # 3.c If we reach here, the new .mmdb differs or the old one did not exist
+    echo "  New or changed ${db} detected; installing updated .mmdb..."
+
+    # 3.d Move new .mmdb into place atomically :contentReference[oaicite:4]{index=4}
+    mv "${tmp_mmdb}" "${dest_file}"
+    echo "  Moved ${db}.mmdb to ${dest_file}"
+
+    # 3.e Set correct ownership
+    chown wazuh-indexer:wazuh-indexer "${dest_file}"
+
+    UPDATED_ANY=true
+    return 0
+}
+
+#############################
+# 4. Stop Wazuh Indexer before updates (optional but recommended)
+#############################
+echo "Stopping Wazuh Indexer service..."
+if systemctl is-active --quiet wazuh-indexer; then
+    systemctl stop wazuh-indexer
+    echo "  Wazuh Indexer stopped."
+else
+    echo "  Wazuh Indexer is not running; skipping stop."
+fi
+
+#############################
+# 5. Iterate over each DB type
+#############################
+for db_type in "${DB_TYPES[@]}"; do
+    if ! update_db "${db_type}"; then
+        echo "  WARNING: update_db failed for ${db_type}"
+    fi
+done
+
+#############################
+# 6. Cleanup temporary directory
+#############################
+rm -rf "${TEMP_DIR}"
+
+#############################
+# 7. Restart Wazuh Indexer if any DB was updated
+#############################
+if [[ "${UPDATED_ANY}" == true ]]; then
+    echo "Restarting Wazuh Indexer service..."
+    if systemctl restart wazuh-indexer; then
+        echo "  Wazuh Indexer restarted."
+        echo "MaxMind GeoLite2 databases have been updated successfully."
+    else
+        echo "  ERROR: Failed to restart Wazuh Indexer." >&2
+    fi
+else
+    echo "No updates were necessary; Wazuh Indexer will be ensured running by EXIT trap."
+fi
+
+exit 0


### PR DESCRIPTION


PR for updating maxmind database script to include docker multi node deployments.

The script currently covers normal AIO and 'onprem' environments as well as docker ones. K8s environments are essentially the same, just replacing the docker comands for kubectl.
