### PR TITLE
ai-assistant: add demo recording kit

### DIFF
--- a/integrations/ai-assistant/.env.example
+++ b/integrations/ai-assistant/.env.example
@@ -19,6 +19,10 @@ KC_REALM=wazuh-poc
 KC_CLIENT_ID=wazuh-ai
 # In-network URL used by the shim to fetch JWKS
 KC_URL=http://keycloak:8080
+# Public-facing Keycloak URL: pins the token issuer (KC_HOSTNAME) and is what
+# the shim expects in the `iss` claim. Must match how users reach Keycloak.
+KC_PUBLIC_URL=http://localhost:8085
+KC_ISSUER=http://localhost:8085/realms/wazuh-poc
 
 # ---- Inference backend (pick ONE option, see README s3) ----------------------
 # WAI_LLM_PROVIDER selects the adapter in tool-service/app/llm.py:

--- a/integrations/ai-assistant/auth-shim/app/main.py
+++ b/integrations/ai-assistant/auth-shim/app/main.py
@@ -28,6 +28,9 @@ class Settings(BaseSettings):
     tenant: str = "lab"
     kc_url: str = "http://keycloak:8080"
     kc_realm: str = "wazuh-poc"
+    # Expected `iss` claim. Split from kc_url because the JWKS is fetched over
+    # the in-network URL while tokens carry the IdP's public-facing issuer.
+    kc_issuer: str = ""
     jwt_issuer: str = "wazuh-ai-shim.lab"
     backend_audience: str = "wazuh-ai-backend.lab"
     indexer_audience: str = "wazuh-indexer.lab"
@@ -63,7 +66,7 @@ def exchange(authorization: str = Header(...)) -> dict:
             token,
             signing_key.key,
             algorithms=["RS256"],
-            issuer=f"{CFG.kc_url}/realms/{CFG.kc_realm}",
+            issuer=CFG.kc_issuer or f"{CFG.kc_url}/realms/{CFG.kc_realm}",
             # Keycloak access tokens default aud to "account"; we pin issuer +
             # signature + azp instead. verify: tighten aud once the customer
             # IdP's token shape is known.

--- a/integrations/ai-assistant/demo/README.md
+++ b/integrations/ai-assistant/demo/README.md
@@ -1,0 +1,38 @@
+# Demo recording
+
+`demo.sh` is a one-take terminal demo of the harness: OIDC login, turn-JWT
+exchange, the read-allowed/write-denied ceiling with no AI involved, one real
+question with its verifiability label, and one zero-hit honesty case. It only
+needs the stack up and seeded first:
+
+```bash
+make keys wazuh securityconfig poc seed
+./demo/demo.sh          # dry run it once before recording
+```
+
+Two ways to record it:
+
+**GIF via VHS** (recommended for the README - deterministic and re-recordable):
+
+```bash
+go install github.com/charmbracelet/vhs@latest   # or: brew install vhs
+vhs demo/demo.tape                               # writes demo/demo.gif
+```
+
+Adjust the two long `Sleep` values in `demo.tape` to your model's latency
+(local models need more, lane 0 hits need almost none), then re-run `vhs`.
+Embed it at the top of the main README:
+
+```markdown
+![Demo: one question through the harness, with its verifiability label](demo/demo.gif)
+```
+
+**Cast via asciinema** (lighter, plays in the browser):
+
+```bash
+asciinema rec -c ./demo/demo.sh demo.cast
+asciinema upload demo.cast        # or: agg demo.cast demo/demo.gif
+```
+
+Keep the recording under a minute: the point is the verifiability label and
+the 403, not the model's prose.

--- a/integrations/ai-assistant/demo/demo.sh
+++ b/integrations/ai-assistant/demo/demo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# One-take demo of the ai-assistant harness. Assumes the stack is up and seeded:
+#   make keys wazuh securityconfig poc seed
+# Record it with either:
+#   vhs demo/demo.tape                          (GIF, deterministic)
+#   asciinema rec -c ./demo/demo.sh demo.cast   (cast, then: agg demo.cast demo.gif)
+set -euo pipefail
+
+say() { printf '\n\033[1;36m# %s\033[0m\n' "$*"; sleep 1; }
+
+say "1. Log in as analyst1 (OIDC password grant against Keycloak)"
+OIDC=$(curl -s http://localhost:8085/realms/wazuh-poc/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=wazuh-ai \
+  -d username=analyst1 -d password=analyst1 | jq -r .access_token)
+echo "OIDC token: ${OIDC:0:24}..."
+
+say "2. Exchange it at the auth shim for a turn JWT (<=10 min, tenant from config)"
+TURN=$(curl -s -X POST http://localhost:8081/v1/token/exchange \
+  -H "Authorization: Bearer $OIDC" | jq -r .access_token)
+echo "turn JWT:   ${TURN:0:24}..."
+
+say "3. The ceiling, with no AI involved: reads allowed, writes denied (403)"
+curl -sk -H "Authorization: Bearer $TURN" \
+  "https://localhost:9200/wazuh-alerts-*/_count" | jq '{alerts_readable: .count}'
+curl -sk -X DELETE -H "Authorization: Bearer $TURN" \
+  -o /dev/null -w 'DELETE wazuh-alerts-* -> HTTP %{http_code}\n' \
+  "https://localhost:9200/wazuh-alerts-4.x-2026.07.08"
+
+say "4. Ask a real question - the answer carries its own verifiability label"
+curl -s -X POST http://localhost:8080/v1/chat/sync \
+  -H "Authorization: Bearer $TURN" -H "Content-Type: application/json" \
+  -d '{"text": "How many authentication failures in the last 24 hours, and which users are targeted?"}' \
+  | jq '{answer, verifiability, tools: .tools_called, usage}'
+
+say "5. Zero-hit honesty: a question about an agent that does not exist"
+curl -s -X POST http://localhost:8080/v1/chat/sync \
+  -H "Authorization: Bearer $TURN" -H "Content-Type: application/json" \
+  -d '{"text": "Show me alerts from agent db-99 today"}' \
+  | jq '{answer, verifiability}'
+
+say "Done - every number came from the datastore, every claim is cited, nothing was trusted"

--- a/integrations/ai-assistant/demo/demo.sh
+++ b/integrations/ai-assistant/demo/demo.sh
@@ -8,15 +8,26 @@ set -euo pipefail
 
 say() { printf '\n\033[1;36m# %s\033[0m\n' "$*"; sleep 1; }
 
+need_token() { # fail fast with the raw response instead of carrying "null" forward
+  if [ -z "$2" ] || [ "$2" = "null" ]; then
+    printf '\033[1;31m%s failed - raw response:\033[0m\n%s\n' "$1" "$3" >&2
+    exit 1
+  fi
+}
+
 say "1. Log in as analyst1 (OIDC password grant against Keycloak)"
-OIDC=$(curl -s http://localhost:8085/realms/wazuh-poc/protocol/openid-connect/token \
+OIDC_RAW=$(curl -s http://localhost:8085/realms/wazuh-poc/protocol/openid-connect/token \
   -d grant_type=password -d client_id=wazuh-ai \
-  -d username=analyst1 -d password=analyst1 | jq -r .access_token)
+  -d username=analyst1 -d password=analyst1)
+OIDC=$(jq -r .access_token <<<"$OIDC_RAW")
+need_token "OIDC login" "$OIDC" "$OIDC_RAW"
 echo "OIDC token: ${OIDC:0:24}..."
 
 say "2. Exchange it at the auth shim for a turn JWT (<=10 min, tenant from config)"
-TURN=$(curl -s -X POST http://localhost:8081/v1/token/exchange \
-  -H "Authorization: Bearer $OIDC" | jq -r .access_token)
+TURN_RAW=$(curl -s -X POST http://localhost:8081/v1/token/exchange \
+  -H "Authorization: Bearer $OIDC")
+TURN=$(jq -r .access_token <<<"$TURN_RAW")
+need_token "token exchange" "$TURN" "$TURN_RAW"
 echo "turn JWT:   ${TURN:0:24}..."
 
 say "3. The ceiling, with no AI involved: reads allowed, writes denied (403)"

--- a/integrations/ai-assistant/demo/demo.tape
+++ b/integrations/ai-assistant/demo/demo.tape
@@ -19,9 +19,9 @@ Enter
 Sleep 12s
 
 # Step 4 runs a real model turn - give it room to finish
-Sleep 45s
+Sleep 120s
 
 # Step 5 zero-hit diagnosis turn
-Sleep 40s
+Sleep 120s
 
 Sleep 5s

--- a/integrations/ai-assistant/demo/demo.tape
+++ b/integrations/ai-assistant/demo/demo.tape
@@ -1,0 +1,27 @@
+# VHS tape for the ai-assistant demo GIF (https://github.com/charmbracelet/vhs)
+# Prereqs: the stack is up and seeded (make keys wazuh securityconfig poc seed),
+# and you run vhs from integrations/ai-assistant/.
+#   vhs demo/demo.tape
+# Output lands at demo/demo.gif - reference it from the top of README.md.
+
+Output demo/demo.gif
+
+Set FontSize 15
+Set Width 1400
+Set Height 800
+Set Padding 16
+Set TypingSpeed 30ms
+
+Type "./demo/demo.sh"
+Enter
+
+# Steps 1-3 are fast (auth + direct indexer probes)
+Sleep 12s
+
+# Step 4 runs a real model turn - give it room to finish
+Sleep 45s
+
+# Step 5 zero-hit diagnosis turn
+Sleep 40s
+
+Sleep 5s

--- a/integrations/ai-assistant/docker-compose.poc.yml
+++ b/integrations/ai-assistant/docker-compose.poc.yml
@@ -12,6 +12,9 @@ services:
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_ADMIN_PASSWORD:-admin}
+      # Pin the issuer so tokens carry the same `iss` no matter which URL
+      # (host localhost:8085 or in-network keycloak:8080) minted them.
+      KC_HOSTNAME: ${KC_PUBLIC_URL:-http://localhost:8085}
     volumes:
       - ./keycloak:/opt/keycloak/data/import:ro
     ports:
@@ -23,6 +26,7 @@ services:
     environment:
       SHIM_TENANT: ${WAI_TENANT:-lab}
       SHIM_KC_URL: ${KC_URL:-http://keycloak:8080}
+      SHIM_KC_ISSUER: ${KC_ISSUER:-http://localhost:8085/realms/wazuh-poc}
       SHIM_KC_REALM: ${KC_REALM:-wazuh-poc}
       SHIM_JWT_ISSUER: ${WAI_JWT_ISSUER:-wazuh-ai-shim.lab}
       SHIM_BACKEND_AUDIENCE: ${WAI_JWT_AUDIENCE:-wazuh-ai-backend.lab}

--- a/integrations/ai-assistant/securityconfig/apply.sh
+++ b/integrations/ai-assistant/securityconfig/apply.sh
@@ -12,9 +12,10 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 CONTAINER="${CONTAINER:-single-node-wazuh.indexer-1}"   # verify: docker ps
-SC_DIR=/usr/share/wazuh-indexer/opensearch-security      # verify per version
-CERTS=/usr/share/wazuh-indexer/certs                     # verify per version
-TOOLS=/usr/share/wazuh-indexer/plugins/opensearch-security/tools
+# Paths as shipped in wazuh-indexer 4.14 images (override via env if yours differ)
+SC_DIR="${SC_DIR:-/usr/share/wazuh-indexer/config/opensearch-security}"
+CERTS="${CERTS:-/usr/share/wazuh-indexer/config/certs}"
+TOOLS="${TOOLS:-/usr/share/wazuh-indexer/plugins/opensearch-security/tools}"
 
 mkdir -p tmp
 for f in config.yml roles.yml roles_mapping.yml; do

--- a/integrations/ai-assistant/securityconfig/merge_securityconfig.py
+++ b/integrations/ai-assistant/securityconfig/merge_securityconfig.py
@@ -11,7 +11,6 @@ Adds, idempotently:
 
 Usage: merge_securityconfig.py <dir-with-the-three-files> <public-key.pem>
 """
-import base64
 import sys
 from pathlib import Path
 
@@ -25,7 +24,11 @@ AUDIENCE = f"wazuh-indexer.{TENANT}"
 def main() -> None:
     workdir = Path(sys.argv[1])
     pubkey_pem = Path(sys.argv[2]).read_text()
-    signing_key = base64.b64encode(pubkey_pem.encode()).decode()
+    # The security plugin routes on the key's shape: a value starting with
+    # -----BEGIN is parsed as an RSA/ECDSA PEM, anything else is treated as a
+    # base64 HMAC secret. Base64-encoding the PEM lands in the HMAC branch and
+    # every RS256 token fails verification, so pass the PEM through verbatim.
+    signing_key = pubkey_pem
 
     # ---- config.yml: the JWT auth domain -----------------------------------
     cfg_path = workdir / "config.yml"


### PR DESCRIPTION
Follow-up to #16. Adds demo/demo.sh (a one-take terminal demo: OIDC login, turn-JWT exchange, the read-allowed/write-denied ceiling, one real question with its verifiability label, and the zero-hit honesty case), a VHS tape that renders it to demo/demo.gif reproducibly, and instructions covering both the VHS and asciinema routes. Recording requires the live stack, so the GIF itself is generated locally and committed separately.